### PR TITLE
Fix error in readme that was giving wrong script to curl | bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lunch menu in terminal & highlights *Köttbullar*
 
 ## Install
 ```
-$ curl "https://raw.githubusercontent.com/lasanjin/expressen-lunch-cli/master/expressen.py" | bash
+$ curl "https://raw.githubusercontent.com/lasanjin/expressen-lunch-cli/master/install.sh" | bash
 ```
 
 ## How to run


### PR DESCRIPTION
In the README under ##install I added the wrong script to curl | bash in the last pr. This changes the README to the right script 